### PR TITLE
Hotfix in svelte and cli demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It's built to handle the ambiguities of LLM-generated streams, which often produ
 
 ### ⚠️ ***Please note that this project is in an early stage of development, so there are MANY bugs and missing features.***
 
-Giving this repository a star ***★*** is a great way to encourage faster development!
+<br>
 
 ### DEMO: [markdown-stream-parser.lixpi.org](https://markdown-stream-parser.lixpi.org)
 

--- a/demo/debug-scripts/char-streamer.ts
+++ b/demo/debug-scripts/char-streamer.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 
 import { log, info, infoStr, warn, err } from './debug-tools.ts'
 
-import MarkdownStreamParser from '../../src/markdown-stream-parser.ts'
+import { MarkdownStreamParser } from '../../src/markdown-stream-parser.ts'
 
 // Parse CLI arguments
 const args = process.argv.slice(2);


### PR DESCRIPTION
This pull request introduces several updates to improve the functionality and user experience of the Markdown stream parser demo, along with minor code adjustments. The most significant changes include enhancing the Svelte demo to support pausing, resuming, and resetting the parser, updating the parser's import style, and refining the demo's UI to display parsed chunks more effectively.

### Enhancements to Svelte Demo Functionality:
* Added support for pausing, resuming, and resetting the Markdown stream parser in the Svelte demo. This includes new functions (`pauseStream`, `processNextToken`, `resetParser`) and adjustments to the `simulateStream` function to handle paused states. (`demo/svelte-demo/src/routes/+page.svelte`, [[1]](diffhunk://#diff-eb27e63505ae3a1f8f3f28c2e4f386e93a82021e0d77fe018f36e8cbc33456fdL50-R180) [[2]](diffhunk://#diff-eb27e63505ae3a1f8f3f28c2e4f386e93a82021e0d77fe018f36e8cbc33456fdL168-R265)
* Replaced `currentParsedChunk` with `currentParsedChunks` to store and display all parsed chunks for the current token. (`demo/svelte-demo/src/routes/+page.svelte`, [[1]](diffhunk://#diff-eb27e63505ae3a1f8f3f28c2e4f386e93a82021e0d77fe018f36e8cbc33456fdL3-R24) [[2]](diffhunk://#diff-eb27e63505ae3a1f8f3f28c2e4f386e93a82021e0d77fe018f36e8cbc33456fdL232-R337)

### UI Improvements:
* Updated the Svelte demo UI to include new buttons for pausing, processing the next token, and resetting the parser. Added a scrollable view for parsed chunks and improved the display of parsed data. (`demo/svelte-demo/src/routes/+page.svelte`, [[1]](diffhunk://#diff-eb27e63505ae3a1f8f3f28c2e4f386e93a82021e0d77fe018f36e8cbc33456fdL168-R265) [[2]](diffhunk://#diff-eb27e63505ae3a1f8f3f28c2e4f386e93a82021e0d77fe018f36e8cbc33456fdL232-R337)

### Code Adjustments:
* Changed the import style of `MarkdownStreamParser` in the Svelte demo and `char-streamer.ts` to ensure consistency and compatibility. (`demo/debug-scripts/char-streamer.ts`, [[1]](diffhunk://#diff-5f076282115983011362eee8bbc98abd659c0926f04bf7f26eb1e226d31677f5L5-R5); `demo/svelte-demo/src/routes/+page.svelte`, [[2]](diffhunk://#diff-eb27e63505ae3a1f8f3f28c2e4f386e93a82021e0d77fe018f36e8cbc33456fdL3-R24)